### PR TITLE
Force tor to use a random port

### DIFF
--- a/.github/workflows/run-server.yml
+++ b/.github/workflows/run-server.yml
@@ -166,13 +166,12 @@ jobs:
           # Generate a random port for Tor to use since the default is often
           # taken
           export TOR_SOCKS_PORT="$((1025 + RANDOM % 8975))"
-          echo "SOCKSPort $TOR_SOCKS_PORT" | sudo tee -a /etc/tor/torrc
 
           # Run a hidden service in the background as a daemon -- allow
           # connecting to the ttyd instance via a browser and allow SSH
           tor \
             --runasdaemon 1 \
-            --socksport
+            --socksport $TOR_SOCKS_PORT \
             --hiddenservicedir /home/runner/tor_service \
             --hiddenserviceport "80 127.0.0.1:7681" \
             --hiddenserviceport "22 127.0.0.1:22"

--- a/.github/workflows/run-server.yml
+++ b/.github/workflows/run-server.yml
@@ -163,6 +163,10 @@ jobs:
           sudo service tor stop
           sudo killall tor || true
 
+          # Generate a random port for Tor to use since the default is often taken
+          export TOR_SOCKS_PORT="$((1000 + RANDOM % 9000))"
+          echo "SOCKSPort $TOR_SOCKS_PORT" | sudo tee -a /etc/tor/torrc
+
           # Run a hidden service in the background as a daemon -- allow
           # connecting to the ttyd instance via a browser and allow SSH
           tor \

--- a/.github/workflows/run-server.yml
+++ b/.github/workflows/run-server.yml
@@ -163,14 +163,16 @@ jobs:
           sudo service tor stop
           sudo killall tor || true
 
-          # Generate a random port for Tor to use since the default is often taken
-          export TOR_SOCKS_PORT="$((1000 + RANDOM % 9000))"
+          # Generate a random port for Tor to use since the default is often
+          # taken
+          export TOR_SOCKS_PORT="$((1025 + RANDOM % 8975))"
           echo "SOCKSPort $TOR_SOCKS_PORT" | sudo tee -a /etc/tor/torrc
 
           # Run a hidden service in the background as a daemon -- allow
           # connecting to the ttyd instance via a browser and allow SSH
           tor \
             --runasdaemon 1 \
+            --socksport
             --hiddenservicedir /home/runner/tor_service \
             --hiddenserviceport "80 127.0.0.1:7681" \
             --hiddenserviceport "22 127.0.0.1:22"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ alternative, non-Tor connection method.
 5. SSH in or connect from the Web using the connection information printed
    during the Action run. Note: whether connection to the `.onion` address
    using the browser or SSH, Tor Browser must be running.
+6. Tor browser has a default setting that causes text to be illegible in `ttyd`
+   and/or its dependency `term.js`. To fix this, go to `about:config` in the
+   address bar, and set `privacy.resistFingerprinting` to `false`.
 
 ## Connect With ngrok (Without Tor)
 


### PR DESCRIPTION
Adds a new entry in the `torrc` file to force Tor to listen on a random port, minimizing the change of a collision.